### PR TITLE
Update branding

### DIFF
--- a/.do/app.template.yaml
+++ b/.do/app.template.yaml
@@ -58,9 +58,8 @@ services:
         value: "__APP_URL_BIND__"
       - key: "ENABLE_EMAIL_INTEGRATION"
         value: "false"
-      - key: "DO_INFERENCE_API_KEY"
-        value: "${DO_INFERENCE_API_KEY}"
-        type: "SECRET"
+      - key: "GRADIENT_AI_INFERENCE_KEY"
+        value: "${GRADIENT_AI_INFERENCE_KEY}"
       - key: "NEXT_PUBLIC_DIGITALOCEAN_GRADIENTAI_ENABLED"
         value: "true"
 

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -69,7 +69,7 @@ spec:
           value: "${APP_URL}"
         - key: "ENABLE_EMAIL_INTEGRATION"
           value: "false"
-        - key: "DO_INFERENCE_API_KEY"
+        - key: "GRADIENT_AI_INFERENCE_KEY"
           value: ""
           type: "SECRET"
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This is a production-ready SaaS Starter Kit for developers who want to build and
 - ✅ File uploads to DigitalOcean Spaces  
 - ✅ PostgreSQL via Prisma ORM  
 - ✅ Next.js + Material UI frontend  
-- ✅ DigitalOcean GradientAI Serverless Inference API 
+- ✅ DigitalOcean Gradient™ AI Serverless Inference API 
 - ✅ Admin dashboard for managing users and subscriptions 
 - ✅ One-click deploy to DO App Platform
 
@@ -56,7 +56,7 @@ The included notes app functionality serves as a practical example of how to bui
 
 > "Build me something like this, but for [my idea]"  
 
-....and it'll scaffold your app using similar patterns — auth, billing, storage, GradientAI Serverless Inference API, etc., all running on DigitalOcean.
+....and it'll scaffold your app using similar patterns — auth, billing, storage, Gradient™ AI Serverless Inference API, etc., all running on DigitalOcean.
 
 ## Technical Stack
 
@@ -69,7 +69,7 @@ The included notes app functionality serves as a practical example of how to bui
 - **Email**: Resend.com
 - **File Storage**: DigitalOcean Spaces
 - **Payments**: Stripe
-- **AI**: DigitalOcean GradientAI Serverless Inference API
+- **AI**: DigitalOcean Gradient™ AI Serverless Inference API
 - **Deployment**: DigitalOcean App Platform
 
 ## Who It's For
@@ -450,12 +450,12 @@ SeaNotes includes AI-powered features that enhance the note-taking experience us
    Update the following values in your `.env` file with your actual API key:
 
    ```
-   DO_INFERENCE_API_KEY=your-digitalocean-inference-api-key
+   GRADIENT_AI_INFERENCE_KEY=your-digitalocean-inference-api-key
    NEXT_PUBLIC_DIGITALOCEAN_GRADIENTAI_ENABLED=true
    ```
 
-   - `DO_INFERENCE_API_KEY`: Your DigitalOcean Inference API key (server-side)
-   - `NEXT_PUBLIC_DIGITALOCEAN_GRADIENTAI_ENABLED`: Enables DigitalOcean Gradient AI features in the frontend (client-side)
+   - `GRADIENT_AI_INFERENCE_KEY`: Your DigitalOcean Inference API key (server-side)
+   - `NEXT_PUBLIC_DIGITALOCEAN_GRADIENTAI_ENABLED`: Enables Gradient™ AI features in the frontend (client-side)
 
 3. **Restart Your Development Server**
 

--- a/application/env-example
+++ b/application/env-example
@@ -99,8 +99,8 @@ STRIPE_PORTAL_CONFIG_ID=          # ID for customer portal configuration
 # ====================
 # General application settings that affect multiple components
 
-# Invoice Generation (DigitalOcean GradientAI)
-# Uses the same DO_INFERENCE_API_KEY as AI title generation
+# Invoice Generation (DigitalOcean Gradient™ AI Platform)
+# Uses the same GRADIENT_AI_INFERENCE_KEY as AI title generation
 INVOICE_PROVIDER=DigitalOcean GradientAI
 
 
@@ -116,7 +116,7 @@ BASE_URL=
 # When configured: Users only enter note content, titles are auto-generated
 # When not configured: Users enter both title and content (traditional flow)
 # In the app: Used by src/services/ai/titleGenerationService.ts for server-side generation
-DO_INFERENCE_API_KEY=             # Your DigitalOcean Inference API key
+GRADIENT_AI_INFERENCE_KEY=             # Your DigitalOcean Inference API key
 
 # Client-side flag to enable DigitalOcean Gradient AI features in the UI
 # Set to 'true' when you want to enable AI-powered content generation

--- a/application/scripts/generate-invoice.js
+++ b/application/scripts/generate-invoice.js
@@ -8,10 +8,10 @@ const path = require('path');
 const OpenAI = require('openai');
 
 // DigitalOcean Serverless Inference configuration
-const apiKey = process.env.DO_INFERENCE_API_KEY;
+const apiKey = process.env.GRADIENT_AI_INFERENCE_KEY;
 
 if (!apiKey) {
-  console.error('❌ Error: API key not found. Please set the DO_INFERENCE_API_KEY environment variable.');
+  console.error('❌ Error: API key not found. Please set the GRADIENT_AI_INFERENCE_KEY environment variable.');
   process.exit(1);
 }
 

--- a/application/src/services/invoice/invoiceService.ts
+++ b/application/src/services/invoice/invoiceService.ts
@@ -39,7 +39,7 @@ export class InvoiceService implements ConfigurableService {
 
   // Required config items with their corresponding env var names and descriptions
   private static requiredConfig = {
-    doInferenceApiKey: { envVar: 'DO_INFERENCE_API_KEY', description: 'DigitalOcean GradientAI Serverless Inference API Key' },
+    doInferenceApiKey: { envVar: 'GRADIENT_AI_INFERENCE_KEY', description: 'DigitalOcean GradientAI Serverless Inference API Key' },
   };
 
   constructor() {
@@ -59,7 +59,7 @@ export class InvoiceService implements ConfigurableService {
       });
     } else {
       this.isConfigured = false;
-      this.lastConnectionError = 'DO_INFERENCE_API_KEY not configured';
+      this.lastConnectionError = 'GRADIENT_AI_INFERENCE_KEY not configured';
     }
   }
 

--- a/application/src/settings.ts
+++ b/application/src/settings.ts
@@ -64,7 +64,7 @@ export const serverConfig: ServerConfig = {
     portalConfigId: process.env.STRIPE_PORTAL_CONFIG_ID,
   },
   GradientAI: {
-    doInferenceApiKey: process.env.DO_INFERENCE_API_KEY,
+    doInferenceApiKey: process.env.GRADIENT_AI_INFERENCE_KEY,
   },
 };
 

--- a/docs/invoice-generation-guide.md
+++ b/docs/invoice-generation-guide.md
@@ -7,7 +7,7 @@ This guide explains how to use **SeaNotes**' AI-powered invoice generation featu
 The invoice generation feature provides:
 
 - **Automatic Invoice Creation**: Generates invoice when users subscribe to plans
-- **AI-Powered Design**: Uses DigitalOcean's GradientAI Serverless Inference API to create invoices
+- **AI-Powered Design**: Uses DigitalOcean's Gradient™ AI Serverless Inference API to create invoices
 - **Email Delivery**: Sends invoices directly to users with PDF attachments
 - **Manual Generation**: Allows users to request invoices on-demand from the billing page
 
@@ -21,7 +21,7 @@ Before setting up invoice generation, ensure you have:
 
 ## Part 1: Set Up DigitalOcean Serverless Inference
 
-The invoice generation feature uses DigitalOcean's [GradientAI Serverless Inference API](https://docs.digitalocean.com/products/gradientai-platform/how-to/use-serverless-inference/) to create professional, AI-generated invoices. Since the system emails invoices to users, you'll need Resend configured for email delivery.
+The invoice generation feature uses DigitalOcean's [Gradient™ AI Serverless Inference API](https://docs.digitalocean.com/products/gradientai-platform/how-to/use-serverless-inference/) to create professional, AI-generated invoices. Since the system emails invoices to users, you'll need Resend configured for email delivery.
 
 ### Step 1: Access DigitalOcean Agent Platform
 
@@ -46,9 +46,9 @@ The invoice generation feature uses DigitalOcean's [GradientAI Serverless Infere
    Add the following environment variable to your `.env` file:
 
    ```bash
-   # Invoice Generation (DigitalOcean GradientAI Serverless Inference)
-   INVOICE_PROVIDER=DigitalOcean GradientAI
-   DO_INFERENCE_API_KEY=your-digitalocean-inference-api-key-here
+   # Invoice Generation (DigitalOcean Gradient™ AI Serverless Inference)
+   INVOICE_PROVIDER=DigitalOcean Gradient™ AI 
+   GRADIENT_AI_INFERENCE_KEY=your-digitalocean-inference-api-key-here
    ```
 
    Replace `your-digitalocean-inference-api-key-here` with the key you copied in Step 2.
@@ -60,9 +60,9 @@ The invoice generation feature uses DigitalOcean's [GradientAI Serverless Infere
    ```yaml
    envs:
      - key: "INVOICE_PROVIDER"
-       value: "DigitalOcean GradientAI"
-     - key: "DO_INFERENCE_API_KEY"
-       value: "${DO_INFERENCE_API_KEY}"
+       value: "DigitalOcean Gradient AI"
+     - key: "GRADIENT_AI_INFERENCE_KEY"
+       value: "${GRADIENT_AI_INFERENCE_KEY}"
        type: "SECRET"
    ```
 
@@ -187,7 +187,7 @@ If the AI service is unavailable, the system gracefully falls back to:
 **Problem**: "Invoice service not configured or connected"
 
 **Solutions**:
-1. Verify `DO_INFERENCE_API_KEY` is set correctly
+1. Verify `GRADIENT_AI_INFERENCE_KEY` is set correctly
 2. Check DigitalOcean Agent Platform access
 3. Ensure the key has proper permissions
 4. Test connection with the script: `node scripts/generate-invoice.js`

--- a/docs/invoice-storage-feature.md
+++ b/docs/invoice-storage-feature.md
@@ -78,7 +78,7 @@ SPACES_REGION=blr1
 SPACES_BUCKET_NAME=sea-notes-storage
 
 # AI Service (for invoice generation)
-DO_INFERENCE_API_KEY=your-do-inference-api-key
+GRADIENT_AI_INFERENCE_KEY=your-do-inference-api-key
 
 # PDF Service (for PDF generation)
 # (Depends on your PDF service configuration)
@@ -191,7 +191,7 @@ Potential improvements for the future:
 
 2. **"Invoice service not configured"**
    - Check AI service configuration
-   - Verify DO_INFERENCE_API_KEY is set
+   - Verify GRADIENT_AI_INFERENCE_KEY is set
 
 3. **"PDF generation failed"**
    - Check PDF service configuration


### PR DESCRIPTION
This pull request updates the naming and usage of the DigitalOcean AI inference API key throughout the codebase and documentation to use `GRADIENT_AI_INFERENCE_KEY` instead of the previous `DO_INFERENCE_API_KEY`. It also standardizes references to the service as "DigitalOcean Gradient™ AI Serverless Inference API" for clarity and branding consistency. These changes affect environment variable names, deployment templates, configuration files, scripts, and documentation.

**Environment variable and configuration updates:**

* Renamed all instances of `DO_INFERENCE_API_KEY` to `GRADIENT_AI_INFERENCE_KEY` in environment files (`application/env-example`), deployment templates (`.do/app.template.yaml`, `.do/deploy.template.yaml`), and server configuration (`application/src/settings.ts`). [[1]](diffhunk://#diff-807a20888650b5b34a9a0f258c699ebe9f46f0a8adb1c87c007892e5c66437ccL61-R62) [[2]](diffhunk://#diff-34cee1c5b84b23fac3cf9b093f6ff491f1613e82bbba84c09e8f31a950aaed69L72-R72) [[3]](diffhunk://#diff-8136ee116b060d68d2791cd8259d040593bdd1056748b5e84493433c00c23766L102-R103) [[4]](diffhunk://#diff-8136ee116b060d68d2791cd8259d040593bdd1056748b5e84493433c00c23766L119-R119) [[5]](diffhunk://#diff-71dfe18c29e86f4e9402ecd428f75a6006962f22ea793466e137df02a8cfcba5L67-R67)

* Updated usage of the API key in code to reference `GRADIENT_AI_INFERENCE_KEY`, including error messages and required config in `generate-invoice.js` and `invoiceService.ts`. [[1]](diffhunk://#diff-1bfcbc8e79fc4c615c157da7118d54bd28f0ed0b3fd96d226fd20f3f74616f3bL11-R14) [[2]](diffhunk://#diff-aa76bc144b9b1a63d019ebfd44f3693f1a73387602a8765ff07db613573af869L42-R42) [[3]](diffhunk://#diff-aa76bc144b9b1a63d019ebfd44f3693f1a73387602a8765ff07db613573af869L62-R62)

**Documentation and branding updates:**

* Standardized all documentation and README references to "DigitalOcean Gradient™ AI Serverless Inference API" and updated instructions to use the new environment variable name. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R49) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-R59) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L72-R72) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L453-R458) [[5]](diffhunk://#diff-5a5479a4a3bcee65dc1e5014157105c129d34c393125c2a92f239b8b91c2d0acL10-R10) [[6]](diffhunk://#diff-5a5479a4a3bcee65dc1e5014157105c129d34c393125c2a92f239b8b91c2d0acL24-R24) [[7]](diffhunk://#diff-5a5479a4a3bcee65dc1e5014157105c129d34c393125c2a92f239b8b91c2d0acL49-R51) [[8]](diffhunk://#diff-5a5479a4a3bcee65dc1e5014157105c129d34c393125c2a92f239b8b91c2d0acL64-R65) [[9]](diffhunk://#diff-5a5479a4a3bcee65dc1e5014157105c129d34c393125c2a92f239b8b91c2d0acL190-R190) [[10]](diffhunk://#diff-7095fcb9c6232ee71e4c6d065f6dbdd6626e936624039f65d71b96b3bbe82501L81-R81) [[11]](diffhunk://#diff-7095fcb9c6232ee71e4c6d065f6dbdd6626e936624039f65d71b96b3bbe82501L194-R194)